### PR TITLE
Rename Edge Engine to "serverless scripting"

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,6 +1,6 @@
 ---
 name: Bug report
-about: Create a bug report to help us improve EdgeEngine examples
+about: Create a bug report to help us improve our serverless scripting examples
 title: ''
 labels: ''
 assignees: ''

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -9,7 +9,7 @@ assignees: ''
 
 **Before continuing**  
 Please make sure your feature request does not contain any sensitive information 
-about you, your ogranization, or your StackPath service.
+about you, your organization, or your StackPath service.
 
 **Is this a feature request for your StackPath service?**  
 If so, please fill out the [feedback form](https://control.stackpath.com/feedback/) 

--- a/.github/contributing.md
+++ b/.github/contributing.md
@@ -1,14 +1,14 @@
-# Contributing to edgeengine-examples
+# Contributing to serverless-scripting-examples
 
-If you're reading this, it seems likely you're interested in contributing to 
-the EdgeEngine examples. Thanks a lot! We think that's awesome! Below are some 
-guidelines to help you get started along with some expectations and tips to make 
-the process easier.
+If you're reading this, it seems likely you're interested in contributing to our 
+serverless scripting examples. Thanks a lot! We think that's awesome! Below are 
+some guidelines to help you get started along with some expectations and tips to 
+make the process easier.
 
 Bug reports and pull requests (PRs) are welcome.
 
 Before coding any new features or substantial changes, please 
-[open a feature request](https://github.com/stackpath/edgeengine-examples/issues/new) 
+[open a feature request](https://github.com/stackpath/serverless-scripting-examples/issues/new) 
 to discuss the proposed changes and benefits provided to the project.
 
 PRs comprised of whitespace fixes, code formatting changes, or other purely 
@@ -20,8 +20,8 @@ cosmetic changes are unlikely to be merged.
 email [security@stackpath.com](mailto:security@stackpath.com).
 
 Before opening an issue, ensure the bug hasn't 
-[already been reported](https://github.com/stackpath/edgeengine-examples/issues). 
-If not, [open a new bug report](https://github.com/stackpath/edgeengine-examples/issues/new) 
+[already been reported](https://github.com/stackpath/serverless-scripting-examples/issues). 
+If not, [open a new bug report](https://github.com/stackpath/serverless-scripting-examples/issues/new) 
 with details demonstrating the unexpected behavior.
 
 PRs are welcome if you've written a patch for a bug.

--- a/README.md
+++ b/README.md
@@ -1,15 +1,17 @@
-# StackPath EdgeEngine Script Examples
+# StackPath Serverless Scripting Examples
 
-The StackPath [EdgeEngine™️](https://www.stackpath.com/services/edgeengine/) provides the
-ability to write custom JavaScript code that is executed at the edge of the StackPath CDN.
-Using **EdgeEngine™️** you can intercept the request before it is sent to your origin server
-or delivered from the cache and modify the response to fit your needs before sending it back
-to the user. **EdgeEngine™️** gives you the power to extend the power of our Global CDN using
-custom code.
+[Serverless Scripting](https://www.stackpath.com/products/edge-computing/serverless-script) 
+provides the ability to write custom JavaScript code that is executed at the 
+edge of the StackPath CDN. With serverless scripting you can intercept the 
+request before it is sent to your origin server or delivered from StackPath's 
+cache and modify the response to fit your needs before sending it back to the 
+user. Serverless scripting gives you the power to extend the power of our global 
+CDN using custom code.
 
-This repository provides examples of how we believe **EdgeEngine™️** can be leveraged to power
-your existing applications. You are welcome to use and modify this code as needed. We would also
-love to see any additional examples you think could be valuable, just submit a pull request.
+This repository provides examples of how we believe serverless scripting can be 
+leveraged to power your existing applications. You are welcome to use and modify 
+this code as needed. We would also love to see any additional examples you think 
+could be valuable. Just submit a pull request.
 
-Questions about **EdgeEngine™️**? Contact our [Support Team](https://support.stackpath.com), we're
-here to help!
+Got questions about serverless scripting? Contact our [Support Team](https://support.stackpath.com). 
+We're here to help!

--- a/aws4-signing/.env.example
+++ b/aws4-signing/.env.example
@@ -8,4 +8,4 @@ SECRET_ACCESS_KEY=""
 REGION="us-east-2"
 
 # Path to the requested asset
-REQUEST_PATH="/edgeengine-test-bucket/pool.jpg"
+REQUEST_PATH="/stackpath-serverless-test-bucket/pool.jpg"

--- a/aws4-signing/README.md
+++ b/aws4-signing/README.md
@@ -1,12 +1,17 @@
 # AWS Signature 4 Request Signing
 
-This script demonstrates how to access assets on AWS using the [Signature Version 4 Signing Process](https://docs.aws.amazon.com/general/latest/gr/signature-version-4.html). The script makes use of [aws4](https://github.com/mhart/aws4) to perform the request signing. This script demonstrates accessing s3, but this method can be used to access nearly all AWS services.
+This script demonstrates how to access assets on AWS using the 
+[Signature Version 4 Signing Process](https://docs.aws.amazon.com/general/latest/gr/signature-version-4.html). 
+The script makes use of [aws4](https://github.com/mhart/aws4) to perform 
+request signing. This script demonstrates accessing s3, but this method can be 
+used to access nearly all AWS services.
 
 ## Getting Started
 
 ### Install Dependencies
 
-[Install yarn](https://yarnpkg.com/en/docs/install) if it is not already installed and run it from the root of the `aws4-signing` directory
+[Install yarn](https://yarnpkg.com/en/docs/install) if it is not already 
+installed and run it from the root of the `aws4-signing` directory
 
 ```bash
 yarn
@@ -27,7 +32,9 @@ SECRET_ACCESS_KEY=""
 REGION="us-east-2"
 
 # Path to the requested asset
-REQUEST_PATH="/edgeengine-test-bucket/pool.jpg"
+REQUEST_PATH="/stackpath-serverless-test-bucket/pool.jpg"
 ```
 
-Copy its contents to a `.env` file and fill in the values specific to your s3 instance. [See instructions](https://docs.aws.amazon.com/general/latest/gr/aws-sec-cred-types.html#access-keys-and-secret-access-keys) for obtaining `ACCESS_KEY_ID` and `SECRET_ACCESS_KEY_ID`.
+Copy its contents to a `.env` file and fill in the values specific to your s3 
+instance. [See instructions](https://docs.aws.amazon.com/general/latest/gr/aws-sec-cred-types.html#access-keys-and-secret-access-keys) 
+for obtaining `ACCESS_KEY_ID` and `SECRET_ACCESS_KEY_ID`.

--- a/aws4-signing/package.json
+++ b/aws4-signing/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.0",
   "main": "index.js",
   "license": "MIT",
+  "private": true,
   "devDependencies": {
     "dotenv-webpack": "^1.5.7",
     "webpack": "^4.27.1",

--- a/dns-over-https/README.md
+++ b/dns-over-https/README.md
@@ -1,8 +1,9 @@
 # DNS over HTTPS
 
-This is an example of an [EdgeEngine](https://www.stackpath.com/products/edgeengine/) worker that responds to
-[DNS over HTTPS (DoH)](https://en.wikipedia.org/wiki/DNS_over_HTTPS) requests. It delegates all calls to the Google DNS
-over HTTPS server for all requests except for `.stackpath` which it will use another site's IPs for.
+This is an example of a [serverless scripting](https://www.stackpath.com/products/edge-computing/serverless-scripting/) 
+worker that responds to [DNS over HTTPS (DoH)](https://en.wikipedia.org/wiki/DNS_over_HTTPS) 
+requests. It delegates all calls to the Google DNS over HTTPS server for all 
+requests except for `.stackpath` which it will use another site's IPs for.
 
 This is the accompanying code for the blog post
 [Serverless DNS over HTTPS (DoH) at the Edge](https://blog.stackpath.com/serverless-dns-over-https-at-the-edge-doh).
@@ -42,13 +43,13 @@ Firefox [Trusted Recursive Resolver (TRR)](https://wiki.mozilla.org/Trusted_Recu
 
 Now go do `about:networking` and do a `DNS Lookup` for `mywebsite.stackpath`. You should see local IPs.
 
-### Deploy on EdgeEngine
+### Deploy on StackPath's EdgeEngine
 
 Change `proxyDnsTo` in `src/index.ts` to given CDN domain (e.g. `a1b2c3d4.stackpathcdn.com`) and set `logs` to `false`.
 Then compile:
 
     npm run build
 
-Take `dist/index.js` and upload an EdgeEngine script in the [StackPath portal](https://control.stackpath.com/). Also in
+Take `dist/index.js` and upload a serverless script in the [StackPath portal](https://control.stackpath.com/). Also in
 the portal, add `Delivery Domain` for `mywebsite.stackpath`. Then set the Firefox `network.trr.uri` setting to the CDN
 name and should work.

--- a/dns-over-https/README.md
+++ b/dns-over-https/README.md
@@ -43,7 +43,7 @@ Firefox [Trusted Recursive Resolver (TRR)](https://wiki.mozilla.org/Trusted_Recu
 
 Now go do `about:networking` and do a `DNS Lookup` for `mywebsite.stackpath`. You should see local IPs.
 
-### Deploy on StackPath's EdgeEngine
+### Deploy on StackPath's Serverless Scripting Platform
 
 Change `proxyDnsTo` in `src/index.ts` to given CDN domain (e.g. `a1b2c3d4.stackpathcdn.com`) and set `logs` to `false`.
 Then compile:

--- a/graphql/README.md
+++ b/graphql/README.md
@@ -1,6 +1,7 @@
 # graphql-js
 
-This script demonstrates using [GraphQL.js](https://github.com/graphql/graphql-js) as an API Gateway at the edge. The GraphQL schema contains two queryable fields
+This script demonstrates using [GraphQL.js](https://github.com/graphql/graphql-js) 
+as an API gateway at the edge. The GraphQL schema contains two queryable fields:
 
 ```graphql
 type Query {
@@ -14,15 +15,20 @@ type SunData {
 }
 ```
 
-`hello` returns a static String while `sun` requests the [sunrise-sunset api](https://sunrise-sunset.org/api) to return the sunrise and sunset time for a particular day and place. The ideal use case for running GraphQL at the edge would involve caching API responses in the CDN so that requests would not need to travel back to the origin every time.
+`hello` returns a static `String` while `sun` requests the [sunrise-sunset api](https://sunrise-sunset.org/api) 
+to return the sunrise and sunset time for a particular day and place. The ideal 
+use case for running GraphQL at the edge involves caching API responses in the 
+CDN so that requests would not need to travel back to the origin every time.
 
-Note: The sunrise sunset API is a public third-party API. StackPath makes no guarantees to its uptime or availability.
+Note: The sunrise sunset API is a public third-party API. StackPath makes no 
+guarantees to its uptime or availability.
 
 ## Getting Started
 
 ### Install Dependencies
 
-[Install yarn](https://yarnpkg.com/en/docs/install) if it is not already installed and run it from the root of the `graphql` directory
+[Install yarn](https://yarnpkg.com/en/docs/install) if it is not already 
+installed and run it from the root of the `graphql` directory
 
 ```bash
 yarn
@@ -36,12 +42,15 @@ To build the project, run
 yarn build
 ```
 
-The output `dist/main.js` can be run from the EdgeEngine.
+The output `dist/main.js` can be run from StackPath's EdgeEngine.
 
 ### Curl Example
 
 ```bash
-curl -X POST -H "Content-Type: application/json" --data '{ "query": "{ hello, sun(lat: 36.7201600, long: -4.4203400, date: \"today\") { sunrise, sunset } }" }' <script-url>
+curl -X POST \
+  -H "Content-Type: application/json" \
+  --data '{ "query": "{ hello, sun(lat: 36.7201600, long: -4.4203400, date: \"today\") { sunrise, sunset } }" }' \
+  <script-url>
 ```
 
 The above query returns a response similar to

--- a/jwt-validation/README.md
+++ b/jwt-validation/README.md
@@ -1,24 +1,24 @@
-# JWT EdgeEngine Validation
+# JWT Validation
 
-The StackPath [EdgeEngine™️](https://www.stackpath.com/services/edgeengine/) provides the
-ability to write custom JavaScript code that is executed at the edge of the StackPath CDN.
-This repo provides an example of how
-[EdgeEngine™️](https://www.stackpath.com/services/edgeengine/) can be used to validate JWTs
-used for API authentication at the edge. Handling JWT validation at the edge will ensure
-that your API servers only see authenticated requests.
+StackPath's [serverless scripting](https://www.stackpath.com/products/edge-computing/serverless-scripting/) 
+provides the ability to write custom JavaScript code that is executed at the 
+edge of the StackPath CDN. This example shows how serverless scripting can be 
+used to validate [JSON Web Tokens](https://jwt.io/) used for API authentication 
+at the edge. Handling JWT validation at the edge ensures that your API servers 
+only see authenticated requests.
 
-This script will only validate that the JWT provided is valid and the signature matches the
-Public Key exposed by your [JWKS](https://auth0.com/docs/jwks) endpoint. If the JWT is
-considered valid, the request will continue to your site and the response is returned to the
-client.
+This script ensures that the JWT provided is valid and the signature matches the
+public key exposed by your [JWKS](https://auth0.com/docs/jwks) endpoint. If the 
+JWT is considered valid, the request will continue to your site and the response 
+is returned to the client.
 
 ## Getting Started
 
 ### Install Dependencies
 
-This project uses [yarn](https://yarnpkg.com/) to manage dependencies and execute build scripts, please install `yarn` before continuing. Once `yarn` has been installed and after
-you have cloned the repository, you can install the dependencies by executing the following
-command.
+This project uses [yarn](https://yarnpkg.com/) to manage dependencies and 
+execute build scripts, please install `yarn` before continuing. Then clone this 
+repository. Next, install the dependencies by executing the following command:
 
 ```bash
 $ yarn install
@@ -26,12 +26,12 @@ $ yarn install
 
 ### Building the script
 
-Before building the project, you will want to configure the project to reach out to the
-correct JWKS endpoint. The endpoint the script uses to retrieve your JWKS will be injected
-at build time through [webpack](https://webpack.js.org/). Set the `JWKS_URL` environment
-variable at build time to configure the endpoint that's used by the script. The `JWKS_KID`
-parameter should be set to the `kid` value defined within the JWK that's used for signing
-your JWTs.
+Before building the project, you will want to configure the project to reach out 
+to the correct JWKS endpoint. The endpoint the script uses to retrieve your JWKS 
+is injected at build time through [webpack](https://webpack.js.org/). Set the 
+`JWKS_URL` environment variable at build time to configure the endpoint used by 
+the script. Set the `JWKS_KID` parameter to the `kid` value defined in the JWK 
+that's used for signing your JWTs.
 
 ```bash
 $ JWKS_URL="https://example.com/.well-known/jwks.json" JWKS_KID="$KID" yarn build

--- a/jwt-validation/package.json
+++ b/jwt-validation/package.json
@@ -1,14 +1,14 @@
 {
   "name": "edge-engine-jwt-validation",
   "version": "1.0.0",
-  "description": "An example EdgeEngine script that will perform JWT validation of requests",
+  "description": "An example StackPath serverless script that will perform JWT validation of requests",
   "scripts": {
     "build": "webpack -p --progress --colors",
     "start": "webpack-dev-server --open --config webpack/webpack.config.dev.js"
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/stackpath/edgeengine-examples.git"
+    "url": "git+https://github.com/stackpath/serverless-scripting-examples.git"
   },
   "keywords": [
     "serverless",
@@ -17,11 +17,12 @@
     "edge-engine",
     "stackpath"
   ],
-  "author": "stackpath.com",
+  "author": "StackPath, LLC",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/stackpath/edgeengine-examples/issues"
+    "url": "https://github.com/stackpath/serverless-scripting-examples/issues"
   },
+  "private": true,
   "devDependencies": {
     "clean-webpack-plugin": "^0.1.19",
     "eslint": "^5.3.0",

--- a/jwt-validation/src/index.js
+++ b/jwt-validation/src/index.js
@@ -12,7 +12,7 @@ const jwtValidator = new TokenValidator(jwksURL, kid);
 // Create the handler for our requests and inject the JWT validator we built
 const handleRequest = buildRequestHandler(jwtValidator);
 
-// Register the request handler with the EdgeEngine
+// Register the request handler with StackPath's serverless scripting platform
 //
 // eslint-disable-next-line no-restricted-globals
 addEventListener('fetch', (event) => {

--- a/wasm-assembly-script/README.md
+++ b/wasm-assembly-script/README.md
@@ -1,12 +1,14 @@
 # AssemblyScript WebAssembly
 
-This script demonstrates how to use [AssemblyScript](https://github.com/AssemblyScript/assemblyscript) compiled to [WebAssembly](https://webassembly.org/) within a script.
+This script demonstrates how to use [AssemblyScript](https://github.com/AssemblyScript/assemblyscript) 
+compiled to [WebAssembly](https://webassembly.org/) within a script.
 
 ## Getting Started
 
 ### Install Dependencies
 
-[Install yarn](https://yarnpkg.com/en/docs/install) if it is not already installed and run it from the root of the `wasm-assembly-script` directory
+[Install yarn](https://yarnpkg.com/en/docs/install) if it is not already 
+installed and run it from the root of the `wasm-assembly-script` directory
 
 ```bash
 yarn
@@ -14,7 +16,8 @@ yarn
 
 ### AssemblyScript
 
-In our AssemblyScript [file](./assembly/index.ts), we export a function `fib` that returns the nth fibonnaci number
+In our AssemblyScript [file](./assembly/index.ts), we export a function `fib()` 
+that returns the _nth_ [Fibonacci number](https://en.wikipedia.org/wiki/Fibonacci_number)
 
 ```ts
 export function fib(n: i32): i32 {
@@ -32,7 +35,8 @@ export function fib(n: i32): i32 {
 
 ### Build WASM
 
-In order to access this function in our JavaScript script, we need to compile it to a `.wasm` file. To compile the AssemblyScript, run
+In order to access this function in our JavaScript script, we need to compile it 
+to a `.wasm` file. To compile the AssemblyScript, run
 
 ```bash
 yarn asbuild
@@ -42,7 +46,9 @@ which outputs an `optimized.wasm` file in the `build/` directory.
 
 ### Importing WASM
 
-Our script imports the WASM file using [arraybuffer-loader](https://github.com/pine/arraybuffer-loader), setup in our [webpack.config.js](./webpack.config.js). Our script looks like this:
+Our script imports the WASM file using [arraybuffer-loader](https://github.com/pine/arraybuffer-loader), 
+setup in our [webpack.config.js](./webpack.config.js) file. Our script looks 
+like this:
 
 ```js
 import wasmBuffer from "./build/optimized.wasm";
@@ -62,7 +68,9 @@ async function handleRequest() {
 }
 ```
 
-The WASM file is loaded into an ArrayBuffer, used to create a [WebAssembly.Module](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/Module), which is used to create a [WebAssembly.Instance](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/Instance). With the instance, we are able to call our function defined in AssemblyScript.
+The WASM file is loaded into an ArrayBuffer, used to create a [WebAssembly.Module](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/Module), 
+which is used to create a [WebAssembly.Instance](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/Instance). 
+With the instance, we are able to call our function defined in AssemblyScript.
 
 ### Build js
 

--- a/wasm-c/README.md
+++ b/wasm-c/README.md
@@ -1,24 +1,29 @@
 # C WebAssembly
 
-This script demonstrates how to use C code compiled to [WebAssembly](https://webassembly.org/) within a script.
+This script demonstrates how to use C code compiled to [WebAssembly](https://webassembly.org/) 
+within a script.
 
 ## Getting Started
 
 ### Install Dependencies
 
-- [Install yarn](https://yarnpkg.com/en/docs/install) if it is not already installed and run it from the root of the `wasm-c` directory
+- [Install yarn](https://yarnpkg.com/en/docs/install) if it is not already 
+installed and run it from the root of the `wasm-c` directory
 
 ```bash
 yarn
 ```
 
-- Follow instructions for installing [Emscripten](https://emscripten.org/docs/getting_started/downloads.html)
+- Follow the instructions for installing [Emscripten](https://emscripten.org/docs/getting_started/downloads.html)
 
 ### C
 
-In our C [file](./C/fib.c), we define a function `fib` that returns the nth fibonnaci number. `EMSCRIPTEN_KEEPALIVE` informs Emscripten that we want to keep this function in our build even though nothing is calling it.
+In our [C file](./C/fib.c), we define a function `fib()` that returns the _nth_ 
+[Fibonacci number](https://en.wikipedia.org/wiki/Fibonacci_number). `EMSCRIPTEN_KEEPALIVE` 
+informs Emscripten that we want to keep this function in our build even though 
+nothing is calling it.
 
-```C
+```c
 #include <emscripten.h>
 
 EMSCRIPTEN_KEEPALIVE
@@ -37,17 +42,23 @@ int fib(int n)
 
 ### Build WASM
 
-In order to access this function in our JavaScript script, we need to compile it to a `.wasm` file. [Emscripten](https://emscripten.org/docs/getting_started/downloads.html) performs this compilation step. Assuming it has been installed correctly, run
+In order to access this function in our JavaScript script, we need to compile it 
+to a `.wasm` file. [Emscripten](https://emscripten.org/) performs this 
+compilation step. Assuming it has been installed correctly, run
 
 ```bash
 yarn build:wasm
 ```
 
-which outputs `build/fib.js` and `build/fib.wasm`. The JavaScript file contains code to make initializaing the [WebAssembly.Instance](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/Instance) easier and additional glue code.
+which outputs `build/fib.js` and `build/fib.wasm`. The JavaScript file contains 
+code to make initializing the [WebAssembly.Instance](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/Instance) 
+easier and additional glue code.
 
 ### Importing WASM
 
-Our script imports the WASM file using [arraybuffer-loader](https://github.com/pine/arraybuffer-loader), setup in our [webpack.config.js](./webpack.config.js). Our script looks like this:
+Our script imports the WASM file using [arraybuffer-loader](https://github.com/pine/arraybuffer-loader), 
+setup in our [webpack.config.js](./webpack.config.js). Our script looks like 
+this:
 
 ```js
 import wasmBinary from "./build/fib.wasm";
@@ -65,7 +76,11 @@ async function handleRequest() {
 }
 ```
 
-The WASM file is loaded into an ArrayBuffer and is passed to the WasmModule that the build Emscripten js file exports. By including the WASM file contents in the script, it prevents having to fetch it separately, as would be typical in a browser setting. Our instance allows us to call our original function defined in C, prefixed with an underscore.
+The WASM file is loaded into an ArrayBuffer and is passed to the WasmModule that 
+the build Emscripten js file exports. By including the WASM file contents in the 
+script, it prevents having to fetch it separately, as would be typical in a 
+browser setting. Our instance allows us to call our original function defined in 
+C, prefixed with an underscore.
 
 ### Build js
 


### PR DESCRIPTION
StackPath now uses the term EdgeEngine to mean the entire platform instead of just the serverless scripting product in the platform. Rename instances and combinations of "Edge Engine" to "serverless scripting" to reflect the change.

Also, give small readability, spelling, and grammar tweaks to markdown files.